### PR TITLE
BUILD: Remove simulator compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ compile_vtk()
 
 set(tags)
 
+if(BUILD_HOST)
+  compile_boost()
+  compile_flann()
+  compile_pcl()
+endif()
+
+
 if(BUILD_ANDROID)
  list(APPEND tags android)
 endif()

--- a/external-project-macros.cmake
+++ b/external-project-macros.cmake
@@ -115,6 +115,28 @@ endmacro()
 #
 # FLANN crosscompile
 #
+macro(compile_flann)
+  set(proj flann-host)
+  ExternalProject_Add(
+    ${proj}
+    SOURCE_DIR ${source_prefix}/flann
+    DOWNLOAD_COMMAND ""
+    DEPENDS flann-fetch
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX:PATH=${install_prefix}/${proj}
+      -DCMAKE_BUILD_TYPE:STRING=${build_type}
+     # -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DBUILD_EXAMPLES:BOOL=OFF
+      -DBUILD_PYTHON_BINDINGS:BOOL=OFF
+      -DBUILD_MATLAB_BINDINGS:BOOL=OFF
+  )
+
+  force_build(${proj})
+endmacro()
+
+#
+# FLANN crosscompile
+#
 macro(crosscompile_flann tag)
   set(proj flann-${tag})
   get_toolchain_file(${tag})
@@ -155,6 +177,26 @@ endmacro()
 #
 # Boost crosscompile
 #
+macro(compile_boost)
+  set(proj boost-host)
+
+  ExternalProject_Add(
+    ${proj}
+    SOURCE_DIR ${source_prefix}/boost
+    DOWNLOAD_COMMAND ""
+    DEPENDS boost-fetch
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX:PATH=${install_prefix}/${proj}
+      -DCMAKE_BUILD_TYPE:STRING=${build_type}
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+  )
+
+  force_build(${proj})
+endmacro()
+
+#
+# Boost crosscompile
+#
 macro(crosscompile_boost tag)
 
 
@@ -189,6 +231,35 @@ macro(fetch_pcl)
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
   )
+endmacro()
+
+#
+# PCL crosscompile
+#
+macro(compile_pcl)
+  set(proj pcl-host)
+
+  ExternalProject_Add(
+    ${proj}
+    SOURCE_DIR ${source_prefix}/pcl
+    DOWNLOAD_COMMAND ""
+    DEPENDS pcl-fetch boost-host flann-host eigen
+    CMAKE_ARGS
+      -DCMAKE_INSTALL_PREFIX:PATH=${install_prefix}/${proj}
+      -DCMAKE_BUILD_TYPE:STRING=${build_type}
+      -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${toolchain_file}
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DPCL_SHARED_LIBS:BOOL=OFF
+      -DBUILD_visualization:BOOL=OFF
+      -DBUILD_examples:BOOL=OFF
+      -DEIGEN_INCLUDE_DIR=${install_prefix}/eigen
+      -DFLANN_INCLUDE_DIR=${install_prefix}/flann-host/include
+      -DFLANN_LIBRARY=${install_prefix}/flann-host/lib/libflann_cpp_s.a
+      -DBOOST_ROOT=${install_prefix}/boost-host
+      -C ${try_run_results_file}
+  )
+
+  force_build(${proj})
 endmacro()
 
 #

--- a/setup-project-variables.cmake
+++ b/setup-project-variables.cmake
@@ -29,7 +29,7 @@ set(vtk_module_defaults
 option(BUILD_ANDROID "Build for Android" ON)
 option(BUILD_IOS_DEVICE "Build for iOS device" ON)
 option(BUILD_IOS_SIMULATOR "Build for iOS simulator" OFF)
-
+option(BUILD_HOST "Build for host" ON)
 
 set(toolchain_dir ${CMAKE_SOURCE_DIR}/toolchains)
 set(toolchain_ios_simulator ${toolchain_dir}/toolchain-ios-simulator.cmake)

--- a/toolchains/toolchain-ios-simulator.cmake
+++ b/toolchains/toolchain-ios-simulator.cmake
@@ -13,16 +13,7 @@ find_program(CMAKE_CXX_COMPILER NAME g++
   NO_DEFAULT_PATH)
 
 set(CMAKE_OSX_ARCHITECTURES i386)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmessage-length=0 -pipe")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-trigraphs -fpascal-strings")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -Wreturn-type -Wunused-variable")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -fasm-blocks -mmacosx-version-min=10.6")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gdwarf-2 -fvisibility=hidden")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-abi-version=2 -fobjc-legacy-dispatch")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__IPHONE_OS_VERSION_MIN_REQUIRED=40300")
-#set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
-
 
 # Set the CMAKE_OSX_SYSROOT to the latest SDK found
 set(CMAKE_OSX_SYSROOT)


### PR DESCRIPTION
Not sure the need for these and they make the binaries very large.

Pat: Is there any reason I should be keeping these around?  I also plan to do similar changes upstream in VES.